### PR TITLE
Define the nanobind target's public include_directories as SYSTEM includes

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -236,7 +236,7 @@ function (nanobind_build_library TARGET_NAME)
       ${NB_DIR}/ext/robin_map/include)
   endif()
 
-  target_include_directories(${TARGET_NAME} PUBLIC
+  target_include_directories(${TARGET_NAME} SYSTEM PUBLIC
     ${Python_INCLUDE_DIRS}
     ${NB_DIR}/include)
 


### PR DESCRIPTION
This change modifies the compile_commands.json for consuming targets to using the `-isystem` switch instead of `-I` for nanobind's public include directories.

This way, analyzer checks (e.g. clang-tidy) are instructed to ignore nanobind headers in their outputs.